### PR TITLE
Fix order placement when using correlation id

### DIFF
--- a/dhanhq/dhanhq.py
+++ b/dhanhq/dhanhq.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 
 
 class dhanhq:
-    
+
     #declaring constants
     NSE= 'NSE_EQ'
     BSE= 'BSE_EQ'
@@ -156,7 +156,7 @@ class dhanhq:
         #quantity(int),order_type(str),validity(str),product_type(str),
         #price(float),trigger_price(float),disclosed_quantity(int),
         #after_market_order(Boolean),amo_time(str),tag(str)
-        
+
         try:
             url= self.base_url+'/orders'
             payload={
@@ -178,7 +178,7 @@ class dhanhq:
                     "drvStrikePrice":drv_strike_price
                 }
             if tag!=None and tag!='':
-                payload["correlationId"] = tag,
+                payload["correlationId"] = tag
             if after_market_order== True:
                 if amo_time in ['OPEN','OPEN_30','OPEN_60']:
                     payload['amoTime'] = amo_time
@@ -242,7 +242,7 @@ class dhanhq:
                 'remarks':str(e),
                 'data':'',
             }
-    
+
     def intraday_daily_minute_charts(self,security_id,exchange_segment,instrument_type):
         """Retrieve OHLC & Volume of 1 minute candle for desired instrument for current day. This data available for all segments including futures & options."""
         try:
@@ -342,7 +342,7 @@ class dhanhq:
         #quantity(int),order_type(str),validity(str),product_type(str),
         #price(float),trigger_price(float),disclosed_quantity(int),
         #after_market_order(Boolean),amo_time(str),tag(str)
-        
+
         try:
             url= self.base_url+'/orders/slicing'
             payload={
@@ -364,7 +364,7 @@ class dhanhq:
                     "drvStrikePrice":drv_strike_price
                 }
             if tag!=None and tag!='':
-                payload["correlationId"] = tag,
+                payload["correlationId"] = tag
             if after_market_order== True:
                 if amo_time in ['OPEN','OPEN_30','OPEN_60']:
                     payload['amoTime'] = amo_time
@@ -416,7 +416,7 @@ class dhanhq:
         try:
             url= self.base_url+'/edis/form'
             data= {
-                    "isin": isin,  
+                    "isin": isin,
                     "qty": qty,
                     "exchange": exchange,
                     "segment": segment,
@@ -439,7 +439,7 @@ class dhanhq:
                 'remarks':str(e),
                 'data':'',
             }
-            
+
     def edis_inquiry(self,isin):
         """Inquires about provided isin"""
         try:


### PR DESCRIPTION
Fix the error:

```
b'{"errorCode":"BAD_REQUEST_ERROR","httpStatus":"BAD_REQUEST","internalErrorCode":"RS-9005","internalErrorMessage":"JSON parse error: Cannot deserialize value of type `java.lang.String` from Array value (token `JsonToken.START_ARRAY`); nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Array value (token `JsonToken.START_ARRAY`)\\n at [Source: (PushbackInputStream); line: 1, column: 272] (through reference chain: co.dhan.api.model.OrderRequest[\\"correlationId\\"])"}'
```

Before:

![Screenshot 2023-03-05 at 4 31 47 AM](https://user-images.githubusercontent.com/22795943/222932525-27bb0e3f-ff4a-4ab0-8c18-fbcc2bcb405e.png)

After:
![Screenshot 2023-03-05 at 4 31 34 AM](https://user-images.githubusercontent.com/22795943/222932523-e774e5cd-d648-4d6c-8e6b-0011ceb1bcb4.png)
