### PR TITLE
Fix: relax argument validations in place_super_order for MARKET and optional legs

### DIFF
--- a/src/dhanhq/_super_order.py
+++ b/src/dhanhq/_super_order.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 class SuperOrder:
     """
     Interface to manage Dhan 'Super Orders', which are composite trading orders that include
@@ -113,11 +115,11 @@ class SuperOrder:
         quantity: int,
         order_type: str,
         product_type: str,
-        price: float | None = None,
-        targetPrice: float | None = None,
-        stopLossPrice: float | None = None,
-        trailingJump: float | None = None,
-        tag: str | None = None
+        price: Optional[float] = None,
+        targetPrice: Optional[float] = None,
+        stopLossPrice: Optional[float] = None,
+        trailingJump: Optional[float] = None,
+        tag: Optional[str] = None
     ):
         """
         Place a new Super Order on Dhan platform with entry, target and stop-loss legs.
@@ -129,11 +131,11 @@ class SuperOrder:
             quantity (int): Order quantity (> 0).
             order_type (str): LIMIT or MARKET.
             product_type (str): CNC, INTRADAY, MARGIN, MTF.
-            price (float | None): Entry price. Set to None for market orders. (default: None)
-            targetPrice (float | None): Target price. (default: None)
-            stopLossPrice (float | None): Stop loss price. (default: None)
-            trailingJump (float | None, optional): Trailing SL value. (default: None)
-            tag (str | None, optional): Optional correlation ID or tracking label. (default: None)
+            price (float, optional): Entry price. Set to None for market orders. (default: None)
+            targetPrice (float, optional): Target price. (default: None)
+            stopLossPrice (float, optional): Stop loss price. (default: None)
+            trailingJump (float, optional): Trailing SL value. (default: None)
+            tag (str, optional): Optional correlation ID or tracking label. (default: None)
 
         Returns:
             dict: The response containing the order placement status.
@@ -159,7 +161,7 @@ class SuperOrder:
 
         # Leg validation
         if order_type == "MARKET":
-            if price:
+            if price is not None and price != 0:
                 raise ValueError("For MARKET orders, price must be None or 0.")
         elif order_type == "LIMIT":
             if price is None or price <= 0:

--- a/src/dhanhq/_super_order.py
+++ b/src/dhanhq/_super_order.py
@@ -105,9 +105,20 @@ class SuperOrder:
 
         return self.dhan_http.delete(f'/super/orders/{order_id}/{order_leg}')
 
-    def place_super_order(self, security_id, exchange_segment, transaction_type, quantity,
-                      order_type, product_type, price, targetPrice, stopLossPrice,
-                      trailingJump, tag):
+    def place_super_order(
+        self,
+        security_id: str,
+        exchange_segment: str,
+        transaction_type: str,
+        quantity: int,
+        order_type: str,
+        product_type: str,
+        price: float | None = None,
+        targetPrice: float | None = None,
+        stopLossPrice: float | None = None,
+        trailingJump: float | None = None,
+        tag: str | None = None
+    ):
         """
         Place a new Super Order on Dhan platform with entry, target and stop-loss legs.
 
@@ -116,13 +127,13 @@ class SuperOrder:
             exchange_segment (str): Exchange (e.g., NSE, BSE).
             transaction_type (str): BUY or SELL.
             quantity (int): Order quantity (> 0).
-            order_type (str): LIMIT, MARKET, etc.
-            product_type (str): CNC, INTRA, etc.
-            price (float): Entry price.
-            targetPrice (float): Target price.
-            stopLossPrice (float): Stop loss price.
-            trailingJump (float): Trailing SL value.
-            tag (str): Optional correlation ID or tracking label.
+            order_type (str): LIMIT or MARKET.
+            product_type (str): CNC, INTRADAY, MARGIN, MTF.
+            price (float | None): Entry price. Set to None for market orders. (default: None)
+            targetPrice (float | None): Target price. (default: None)
+            stopLossPrice (float | None): Stop loss price. (default: None)
+            trailingJump (float | None, optional): Trailing SL value. (default: None)
+            tag (str | None, optional): Optional correlation ID or tracking label. (default: None)
 
         Returns:
             dict: The response containing the order placement status.
@@ -131,39 +142,67 @@ class SuperOrder:
             ValueError: If mandatory inputs are missing or logically invalid.
         """
         # Basic validations
-        if not all([security_id, exchange_segment, transaction_type, quantity, order_type, product_type, price, targetPrice, stopLossPrice]):
+        if not all([security_id, exchange_segment, transaction_type, quantity, order_type, product_type]):
             raise ValueError("Missing required parameters for placing a super order.")
+        
+        security_id = str(security_id)
+        exchange_segment = exchange_segment.upper()
+        transaction_type = transaction_type.upper()
+        quantity = int(quantity)
+        order_type = order_type.upper()
+        product_type = product_type.upper()
+        price = float(price) if price is not None else None
+        targetPrice = float(targetPrice) if targetPrice is not None else None
+        stopLossPrice = float(stopLossPrice) if stopLossPrice is not None else None
+        trailingJump = float(trailingJump) if trailingJump is not None else None
+        tag = str(tag) if tag is not None else None
 
         # Leg validation
-        if price <= 0 or targetPrice <= 0 or stopLossPrice <= 0:
-            raise ValueError("All legs (price, targetPrice, stopLossPrice) must be provided and > 0.")
+        if order_type == "MARKET":
+            if price:
+                raise ValueError("For MARKET orders, price must be None or 0.")
+        elif order_type == "LIMIT":
+            if price is None or price <= 0:
+                raise ValueError("For LIMIT orders, price must be provided and > 0.")
+        else:
+            raise ValueError("order_type must be either MARKET or LIMIT.")
 
-        transaction_type = transaction_type.upper()
-        price = float(price)
-        targetPrice = float(targetPrice)
-        stopLossPrice = float(stopLossPrice)
+        if (targetPrice is None or targetPrice <= 0) and (stopLossPrice is None or stopLossPrice <= 0):
+            raise ValueError("At least one of targetPrice or stopLossPrice must be provided and > 0.")
+        
+        if trailingJump:
+            if trailingJump < 0:
+                raise ValueError("trailingJump must be >= 0.")
+            if not stopLossPrice:
+                raise ValueError("trailingJump can only be used with stopLossPrice. Please provide a valid stopLossPrice.")
 
         # Logical leg validation
         if transaction_type == "BUY":
-            if not (targetPrice > price and stopLossPrice < price):
-                raise ValueError("For BUY: targetPrice must be > price and stopLossPrice must be < price.")
+            if order_type != "MARKET":
+                if targetPrice and not (targetPrice > price):
+                    raise ValueError("For BUY: targetPrice must be > price.")
+                if stopLossPrice and not (stopLossPrice < price):
+                    raise ValueError("For BUY: stopLossPrice must be < price.")
         elif transaction_type == "SELL":
-            if not (targetPrice < price and stopLossPrice > price):
-                raise ValueError("For SELL: targetPrice must be < price and stopLossPrice must be > price.")
+            if order_type != "MARKET":
+                if targetPrice and not (targetPrice < price):
+                    raise ValueError("For SELL: targetPrice must be < price.")
+                if stopLossPrice and not (stopLossPrice > price):
+                    raise ValueError("For SELL: stopLossPrice must be > price.")
         else:
             raise ValueError("transaction_type must be either BUY or SELL.")
 
         payload = {
             "transactionType": transaction_type,
-            "exchangeSegment": exchange_segment.upper(),
-            "productType": product_type.upper(),
-            "orderType": order_type.upper(),
+            "exchangeSegment": exchange_segment,
+            "productType": product_type,
+            "orderType": order_type,
             "securityId": security_id,
-            "quantity": int(quantity),
+            "quantity": quantity,
             "price": price,
-            "targetPrice": float(targetPrice),
-            "stopLossPrice": float(stopLossPrice),
-            "trailingJump": float(trailingJump)
+            "targetPrice": targetPrice,
+            "stopLossPrice": stopLossPrice,
+            "trailingJump": trailingJump
         }
 
         if tag:

--- a/tests/unit/test_dhanhq_super_order.py
+++ b/tests/unit/test_dhanhq_super_order.py
@@ -33,8 +33,8 @@ class TestDhanhq_SuperOrder:
         assert mock_post_request.call_args[0][0] == endpoint
 
     @patch("dhanhq.dhan_http.DhanHTTP.post")
-    def test_place_super_order_invalid_legs(self, mock_post_request, dhanhq_obj):
-        with pytest.raises(ValueError, match="All legs .* must be provided"):
+    def test_place_super_order_invalid_no_legs(self, mock_post_request, dhanhq_obj):
+        with pytest.raises(ValueError, match="At least one of targetPrice or stopLossPrice must be provided and > 0"):
             dhanhq_obj.place_super_order(
                 security_id="SEC123",
                 exchange_segment="NSE",
@@ -42,10 +42,10 @@ class TestDhanhq_SuperOrder:
                 quantity=10,
                 order_type="LIMIT",
                 product_type="INTRA",
-                price=0,
+                price=100,
                 targetPrice=0,
                 stopLossPrice=0,
-                trailingJump=1.5,
+                trailingJump=0,
                 tag=""
             )
 
@@ -65,6 +65,25 @@ class TestDhanhq_SuperOrder:
                 trailingJump=1.5,
                 tag=""
             )
+
+    @patch("dhanhq.dhan_http.DhanHTTP.post")
+    def test_place_super_order_valid_market(self, mock_post_request, dhanhq_obj):
+        endpoint = '/super/orders'
+        dhanhq_obj.place_super_order(
+            security_id="SEC123",
+            exchange_segment="NSE",
+            transaction_type="BUY",
+            quantity=10,
+            order_type="MARKET",
+            product_type="INTRA",
+            price=0,
+            targetPrice=110,
+            stopLossPrice=0,
+            trailingJump=0,
+            tag="TEST_MARKET"
+        )
+        mock_post_request.assert_called_once()
+        assert mock_post_request.call_args[0][0] == endpoint
 
     @patch("dhanhq.dhan_http.DhanHTTP.put")
     def test_modify_super_order_entry_leg(self, mock_put_request, dhanhq_obj):


### PR DESCRIPTION
This PR updates the `place_super_order()` method to:
- Allow `price` = `None` / `0` for `MARKET` orders (as accepted by Dhan API).
- Allow only one of `targetPrice` or `stopLossPrice` to be provided.
- Allow `trailingJump` to be optional or 0.
These changes allow more diverse orders which are allowed by API server but restricted by the current `place_super_order()` method.

Also made appropriate changes to the unit tests for `place_super_order()`.

This fixes the major issue: placing MARKET orders through place_super_order(), which was not possible before this fix. There was no way to place MARKET orders with stop loss and profit target, these changes fixes this issue.

More info in the below issue [Issue 87](https://github.com/dhan-oss/DhanHQ-py/issues/87):
Fixes #87 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation and logical checks when placing super orders, ensuring required parameters are present and correctly formatted.
  * Enhanced error messages for missing or invalid order parameters.

* **Tests**
  * Updated and renamed tests to reflect new validation logic.
  * Added a new test to verify correct behavior when placing a valid market super order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->