### PR TITLE
added missing dummy payload

### DIFF
--- a/src/dhanhq/_trader_control.py
+++ b/src/dhanhq/_trader_control.py
@@ -16,5 +16,5 @@ class TraderControl:
         """
         action = action.upper()
         endpoint = f'/killswitch?killSwitchStatus={action}'
-        
-        return self.dhan_http.post(endpoint)
+        payload = {}
+        return self.dhan_http.post(endpoint, payload)


### PR DESCRIPTION
api can not be called because of missing payload field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the kill switch by sending an explicit empty payload with the request. This aligns with API expectations, preventing intermittent failures and ensuring consistent behavior across environments. No user action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->