### PR TITLE
Fix: Add graceful disconnect for OrderUpdate

### DIFF
--- a/src/dhanhq/orderupdate.py
+++ b/src/dhanhq/orderupdate.py
@@ -40,6 +40,7 @@ class OrderUpdate:
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
         self._running = False
+        self._connecting = False
         self.on_connect = on_connect
         self.on_close = on_close
 
@@ -47,63 +48,81 @@ class OrderUpdate:
         """
         Connects to the WebSocket and authenticates.
         """
-        self.ws = await websockets.connect(self.order_feed_wss)
-        auth_message = {
-            "LoginReq": {
-                "MsgCode": 42,
-                "ClientId": str(self.client_id),
-                "Token": str(self.access_token)
-            },
-            "UserType": "SELF"
-        }
-        await self.ws.send(json.dumps(auth_message))
-        print(f"Sent subscribe message: {auth_message}")
+        ws = self.ws
+        if ws and not self._is_ws_closed(ws):
+            return
 
-        if self.on_connect:
-            self.on_connect(self)
+        while self._connecting:
+            await asyncio.sleep(0.1)
+
+        ws = self.ws
+        if ws and not self._is_ws_closed(ws):
+            return
+
+        self._connecting = True
+        try:
+            self.ws = await websockets.connect(self.order_feed_wss)
+            auth_message = {
+                "LoginReq": {
+                    "MsgCode": 42,
+                    "ClientId": str(self.client_id),
+                    "Token": str(self.access_token)
+                },
+                "UserType": "SELF"
+            }
+            await self.ws.send(json.dumps(auth_message))
+            print(f"Sent subscribe message: {auth_message}")
+
+            if self.on_connect:
+                self.on_connect(self)
+        finally:
+            self._connecting = False
 
     async def _run_async(self):
         """Internal async method to handle the connection loop."""
         await self.connect()
         while self._running:
+            ws = self.ws
             try:
-                if self.ws and not self._is_ws_closed():
-                    message = await asyncio.wait_for(self.ws.recv(), timeout=1)
+                if ws and not self._is_ws_closed(ws):
+                    message = await asyncio.wait_for(ws.recv(), timeout=1)
                     data = json.loads(message)
                     self.handle_order_update(data)
                 else:
                     await asyncio.sleep(1)
-                    if not self._running:
-                        break
-                    if not self.ws or self._is_ws_closed():
+                    ws = self.ws
+                    if self._running and (not ws or self._is_ws_closed(ws)):
                         await self.connect()
             except asyncio.TimeoutError:
                 continue
             except websockets.ConnectionClosed:
                 if self._running:
                     await asyncio.sleep(1)
-                    if not self._running:
-                        break
-                    await self.connect()
+                    if self._running:
+                        await self.connect()
             except Exception as e:
                 if self._running:
                     print(f"Error in order update: {e}")
                     await asyncio.sleep(1)
 
-    def _is_ws_closed(self):
+    def _is_ws_closed(self, ws=None):
         """Helper method to safely check if WebSocket is closed."""
-        if not self.ws:
+        if ws is None:
+            ws = self.ws
+        if not ws:
             return True
         try:
-            return getattr(self.ws, 'closed', False) or self.ws.state == websockets.protocol.State.CLOSED
+            return getattr(ws, 'closed', False) or ws.state == websockets.protocol.State.CLOSED
         except Exception:
             return True
 
     async def disconnect(self):
         """Closes the WebSocket connection gracefully."""
-        if self.ws:
+        ws = self.ws
+        self.ws = None
+        if ws:
             try:
-                await self.ws.close()
+                await ws.close()
             except Exception as e:
                 print(f"Error during disconnect: {e}")
 
@@ -127,9 +146,12 @@ class OrderUpdate:
             try:
                 return future.result(timeout=5)
             except TimeoutError:
+                future.cancel()
                 print("Warning: disconnect timed out")
                 return
         else:
+            if self.loop.is_closed():
+                return
             return self.loop.run_until_complete(self.disconnect())
 
     def run(self):
@@ -142,8 +164,10 @@ class OrderUpdate:
             self.loop.run_until_complete(self._run_async())
         except KeyboardInterrupt:
             self._running = False
-            if self.ws and not self._is_ws_closed():
+            if self.ws:
                 self.loop.run_until_complete(self.disconnect())
+            else:
+                self.ws = None
             self.loop.close()
 
     def start(self):
@@ -177,13 +201,12 @@ class OrderUpdate:
     # Keep for backward compatibility
     async def connect_order_update(self):
         """Deprecated: Use run() or start() instead."""
-        await self.connect()
-        while self._running:
-            message = await self.ws.recv()
-            data = json.loads(message)
-            self.handle_order_update(data)
+        self._running = True
+        await self._run_async()
 
     def connect_to_dhan_websocket_sync(self):
         """Deprecated: Use run() or start() instead."""
-        self._running = True
-        self.run()
+        try:
+            self.run()
+        except Exception as e:
+            print(f"Error in connect_to_dhan_websocket: {e}")

--- a/src/dhanhq/orderupdate.py
+++ b/src/dhanhq/orderupdate.py
@@ -68,7 +68,7 @@ class OrderUpdate:
         while self._running:
             try:
                 if self.ws and not self._is_ws_closed():
-                    message = await self.ws.recv()
+                    message = await asyncio.wait_for(self.ws.recv(), timeout=1)
                     data = json.loads(message)
                     self.handle_order_update(data)
                 else:
@@ -77,6 +77,8 @@ class OrderUpdate:
                         break
                     if not self.ws or self._is_ws_closed():
                         await self.connect()
+            except asyncio.TimeoutError:
+                continue
             except websockets.ConnectionClosed:
                 if self._running:
                     await asyncio.sleep(1)

--- a/src/dhanhq/orderupdate.py
+++ b/src/dhanhq/orderupdate.py
@@ -24,40 +24,132 @@ class OrderUpdate:
 
     on_update: Optional[Callable[[dict], None]] = None
 
-    def __init__(self, dhan_context):
+    def __init__(self, dhan_context, on_connect=None, on_close=None):
         """
         Initializes the OrderSocket with client ID and access token.
 
         Args:
-            client_id (str): The client ID for authentication.
-            access_token (str): The access token for authentication.
+            dhan_context: The Dhan context containing client ID and access token.
+            on_connect: Optional callback when connection is established.
+            on_close: Optional callback when connection is closed.
         """
         self.client_id = dhan_context.get_client_id()
         self.access_token = dhan_context.get_access_token()
         self.order_feed_wss = "wss://api-order-update.dhan.co"
+        self.ws = None
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+        self._running = False
+        self.on_connect = on_connect
+        self.on_close = on_close
 
-    async def connect_order_update(self):
+    async def connect(self):
         """
-        Connects to the WebSocket and listens for order updates.
-
-        This method authenticates the client and processes incoming messages.
+        Connects to the WebSocket and authenticates.
         """
-        async with websockets.connect(self.order_feed_wss) as websocket:
-            auth_message = {
-                "LoginReq": {
-                    "MsgCode": 42,
-                    "ClientId": str(self.client_id),
-                    "Token": str(self.access_token)
-                },
-                "UserType": "SELF"
-            }
+        self.ws = await websockets.connect(self.order_feed_wss)
+        auth_message = {
+            "LoginReq": {
+                "MsgCode": 42,
+                "ClientId": str(self.client_id),
+                "Token": str(self.access_token)
+            },
+            "UserType": "SELF"
+        }
+        await self.ws.send(json.dumps(auth_message))
+        print(f"Sent subscribe message: {auth_message}")
 
-            await websocket.send(json.dumps(auth_message))
-            print(f"Sent subscribe message: {auth_message}")
+        if self.on_connect:
+            self.on_connect(self)
 
-            async for message in websocket:
-                data = json.loads(message)
-                self.handle_order_update(data)
+    async def _run_async(self):
+        """Internal async method to handle the connection loop."""
+        await self.connect()
+        while self._running:
+            try:
+                if self.ws and not self._is_ws_closed():
+                    message = await self.ws.recv()
+                    data = json.loads(message)
+                    self.handle_order_update(data)
+                else:
+                    await asyncio.sleep(1)
+                    if not self._running:
+                        break
+                    if not self.ws or self._is_ws_closed():
+                        await self.connect()
+            except websockets.ConnectionClosed:
+                if self._running:
+                    await asyncio.sleep(1)
+                    if not self._running:
+                        break
+                    await self.connect()
+            except Exception as e:
+                if self._running:
+                    print(f"Error in order update: {e}")
+                    await asyncio.sleep(1)
+
+    def _is_ws_closed(self):
+        """Helper method to safely check if WebSocket is closed."""
+        if not self.ws:
+            return True
+        try:
+            return getattr(self.ws, 'closed', False) or self.ws.state == websockets.protocol.State.CLOSED
+        except Exception:
+            return True
+
+    async def disconnect(self):
+        """Closes the WebSocket connection gracefully."""
+        if self.ws:
+            try:
+                await self.ws.close()
+            except Exception as e:
+                print(f"Error during disconnect: {e}")
+
+        if self.on_close:
+            self.on_close(self)
+        print("Connection closed!")
+
+    def close_connection(self):
+        """Synchronous method to close the WebSocket connection. Thread-safe."""
+        self._running = False
+        try:
+            loop = asyncio.get_running_loop()
+            if loop == self.loop:
+                asyncio.create_task(self.disconnect())
+                return
+        except RuntimeError:
+            pass
+
+        if self.loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(self.disconnect(), self.loop)
+            try:
+                return future.result(timeout=5)
+            except TimeoutError:
+                print("Warning: disconnect timed out")
+                return
+        else:
+            return self.loop.run_until_complete(self.disconnect())
+
+    def run(self):
+        """Blocking call to run the WebSocket connection. Handles KeyboardInterrupt gracefully."""
+        if self.loop.is_closed():
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
+        self._running = True
+        try:
+            self.loop.run_until_complete(self._run_async())
+        except KeyboardInterrupt:
+            self._running = False
+            if self.ws and not self._is_ws_closed():
+                self.loop.run_until_complete(self.disconnect())
+            self.loop.close()
+
+    def start(self):
+        """Starts the WebSocket connection in a separate thread. Returns the thread object."""
+        import threading
+        t = threading.Thread(target=self.run, daemon=True)
+        t.start()
+        return t
 
     def handle_order_update(self, order_update):
         """
@@ -80,17 +172,16 @@ class OrderUpdate:
         else:
             print(f"Unknown message received: {order_update}")
 
-    def connect_to_dhan_websocket_sync(self):
-        """
-        Synchronously connects to the WebSocket.
+    # Keep for backward compatibility
+    async def connect_order_update(self):
+        """Deprecated: Use run() or start() instead."""
+        await self.connect()
+        while self._running:
+            message = await self.ws.recv()
+            data = json.loads(message)
+            self.handle_order_update(data)
 
-        This method runs the asynchronous connect_order_update method in a new event loop.
-        """
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(self.connect_order_update())
-        except Exception as e:
-            print(f"Error in connect_to_dhan_websocket: {e}")
-        finally:
-            loop.close()
+    def connect_to_dhan_websocket_sync(self):
+        """Deprecated: Use run() or start() instead."""
+        self._running = True
+        self.run()


### PR DESCRIPTION
## Summary

Fixes #112 — `OrderUpdate` has no `disconnect()` method, causing cascading exceptions on Ctrl+C.

## Problem

The current `OrderUpdate` class uses `async with websockets.connect()` which traps the websocket reference inside the context block. There is no way to trigger a graceful shutdown externally. When a user hits Ctrl+C:

1. `KeyboardInterrupt` fires mid-event-loop
2. `loop.close()` runs while websocket tasks are still pending
3. Cascading `RuntimeError: Event loop is closed` and destroyed pending tasks

The `async with` cleanup path (`__aexit__`) never runs properly during `KeyboardInterrupt` — so the automatic cleanup that's supposed to justify using a context manager doesn't actually work in the failure case.

## Root Cause

Two design issues in the original code:

- **No external access to the websocket** — the `websocket` reference is trapped inside the `async with` block, so no outside code can call `websocket.close()`
- **No way to stop the message loop** — `async for message in websocket` blocks forever; the only exit is an exception, which bypasses clean shutdown

## Fix

Mirrors `MarketFeed`'s lifecycle pattern (which already handles this correctly in the same repo):

| New Method | Purpose |
|---|---|
| `connect()` | Opens websocket manually (no `async with`), stores `self.ws`, authenticates |
| `disconnect()` | `await self.ws.close()` with error logging, fires `on_close` callback |
| `close_connection()` | Sync/thread-safe wrapper with 5s timeout. Handles three cases: same event loop, loop running in another thread, loop stopped |
| `run()` | Blocking entry point. Catches `KeyboardInterrupt` → clean disconnect → close loop. Recreates loop if called again after shutdown |
| `start()` | Spawns `run()` in a daemon thread, returns thread object |
| `_run_async()` | Internal message loop with auto-reconnect on `ConnectionClosed`, tight `_running` checks before every reconnect |
| `_is_ws_closed()` | Safe websocket state check |

### Key design decisions

- **`_running` flag** controls the message loop and prevents reconnect after intentional shutdown
- **Loop created in `__init__`** — consistent with `MarketFeed`'s pattern. Recreated in `run()` if closed (supports retry patterns)
- **`close_connection()` has a 5s timeout** — prevents caller from hanging if websocket close stalls
- **`_running` checked immediately before every reconnect** — not just in the `while` condition — to close race windows after `close_connection()` sets the flag
- **`disconnect()` logs errors** instead of silently swallowing them

### Backward compatibility

Old methods kept as thin wrappers so existing code doesn't break:

```python
async def connect_order_update(self):
    """Deprecated: Use run() or start() instead."""
    await self.connect()
    while self._running:
        message = await self.ws.recv()
        data = json.loads(message)
        self.handle_order_update(data)

def connect_to_dhan_websocket_sync(self):
    """Deprecated: Use run() or start() instead."""
    self._running = True
    self.run()
```

### New optional `__init__` parameters

- `on_connect` — callback fired after websocket connects and authenticates
- `on_close` — callback fired after disconnect

## Usage

```python
from dhanhq import DhanContext, OrderUpdate

dhan_context = DhanContext("client_id", "access_token")

order_client = OrderUpdate(dhan_context)
order_client.on_update = lambda data: print(data["Data"])
order_client.run()  # Ctrl+C now exits cleanly

# Or in a thread:
t = order_client.start()
# ... later:
order_client.close_connection()
```

## Test plan

- [x] Existing unit tests pass (`test_order_update_with_no_callback`, `test_order_update_with_callback`)
- [x] Manual test: run `order_client.run()`, hit Ctrl+C — should exit cleanly with "Connection closed!" and no tracebacks
- [x] Manual test: `order_client.start()` in a thread, call `order_client.close_connection()` — should stop within 5s
- [x] Manual test: call `run()` after Ctrl+C — should reconnect (loop recreated)