### PR TITLE
Fix stale WebSocket close_connection hangs

### DIFF
--- a/src/dhanhq/fulldepth.py
+++ b/src/dhanhq/fulldepth.py
@@ -96,7 +96,26 @@ class FullDepth:
 
     def close_connection(self):
         """Close WebSocket connection with this."""
-        return self.loop.run_until_complete(self.disconnect())
+        try:
+            loop = asyncio.get_running_loop()
+            if loop == self.loop:
+                asyncio.create_task(self.disconnect())
+                return
+        except RuntimeError:
+            pass
+
+        if self.loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(self.disconnect(), self.loop)
+            try:
+                return future.result(timeout=5)
+            except TimeoutError:
+                future.cancel()
+                print("Warning: WebSocket disconnect timed out")
+                return
+        else:
+            if self.loop.is_closed():
+                return
+            return self.loop.run_until_complete(self.disconnect())
 
     async def connect(self):
         """Initiates the connection to the Websockets."""
@@ -128,13 +147,20 @@ class FullDepth:
 
     async def disconnect(self):
         """Closes the WebSocket connection and sends a disconnect message."""
-        if self.ws:
-            disconnect_message = {
-                "RequestCode": 12
-            }
-            await self.ws.send(json.dumps(disconnect_message))
-            header_message = self.create_header(feed_request_code=12, message_length=83, client_id=self.client_id)
-            await self.ws.send(header_message)
+        ws = self.ws
+        self.ws = None
+        if ws:
+            try:
+                disconnect_message = {"RequestCode": 12}
+                await asyncio.wait_for(ws.send(json.dumps(disconnect_message)), timeout=1)
+                header_message = self.create_header(feed_request_code=12, message_length=83, client_id=self.client_id)
+                await asyncio.wait_for(ws.send(header_message), timeout=1)
+            except Exception:
+                pass
+            try:
+                await asyncio.wait_for(ws.close(), timeout=3)
+            except Exception:
+                pass
         print("Connection closed!")
 
     """Creating Instruments List to be subscribed"""

--- a/src/dhanhq/marketfeed.py
+++ b/src/dhanhq/marketfeed.py
@@ -80,8 +80,15 @@ class MarketFeed:
 
         if self.loop.is_running():
             future = asyncio.run_coroutine_threadsafe(self.disconnect(), self.loop)
-            return future.result()
+            try:
+                return future.result(timeout=5)
+            except TimeoutError:
+                future.cancel()
+                print("Warning: WebSocket disconnect timed out")
+                return
         else:
+            if self.loop.is_closed():
+                return
             return self.loop.run_until_complete(self.disconnect())
         
     def run(self):
@@ -181,19 +188,24 @@ class MarketFeed:
 
     async def disconnect(self):
         """Closes the WebSocket connection and sends a disconnect message."""
-        if self.ws:
+        ws = self.ws
+        self.ws = None
+        if ws:
             if self.version == 'v2':
                 disconnect_message = {
                     "RequestCode": 12
                 }
                 try:
-                    await self.ws.send(json.dumps(disconnect_message))
+                    await asyncio.wait_for(ws.send(json.dumps(disconnect_message)), timeout=1)
                     header_message = self.create_header(feed_request_code=12, message_length=83, client_id=self.client_id)
-                    await self.ws.send(header_message)
+                    await asyncio.wait_for(ws.send(header_message), timeout=1)
                 except Exception:
                     pass
-            await self.ws.close()
-            
+            try:
+                await asyncio.wait_for(ws.close(), timeout=3)
+            except Exception:
+                pass
+
         if self.on_close:
             self.on_close(self)
         print("Connection closed!")

--- a/tests/unit/test_dhanhq_fulldepth.py
+++ b/tests/unit/test_dhanhq_fulldepth.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import MagicMock, patch
 import pytest
 from dhanhq import FullDepth, DhanContext
@@ -14,3 +15,58 @@ class TestFullDepth:
         assert depth.client_id == "client_id"
         assert depth.access_token == "access_token"
         assert depth.depth_level == 20 # default
+
+    def test_disconnect_clears_and_closes_websocket(self, mock_context):
+        class MockWebSocket:
+            def __init__(self):
+                self.sent_messages = []
+                self.closed = False
+
+            async def send(self, message):
+                self.sent_messages.append(message)
+
+            async def close(self):
+                self.closed = True
+
+        instruments = [(1, "1333")]
+        depth = FullDepth(mock_context, instruments)
+        ws = MockWebSocket()
+        depth.ws = ws
+
+        depth.loop.run_until_complete(depth.disconnect())
+
+        assert depth.ws is None
+        assert ws.closed
+        assert len(ws.sent_messages) == 2
+
+    def test_close_connection_cancels_disconnect_on_timeout(self, monkeypatch, mock_context):
+        class MockFuture:
+            def __init__(self):
+                self.cancelled = False
+
+            def result(self, timeout=None):
+                assert timeout == 5
+                raise TimeoutError
+
+            def cancel(self):
+                self.cancelled = True
+
+        class MockLoop:
+            def is_running(self):
+                return True
+
+        instruments = [(1, "1333")]
+        depth = FullDepth(mock_context, instruments)
+        depth.loop = MockLoop()
+        future = MockFuture()
+
+        def mock_run_coroutine_threadsafe(coro, loop):
+            coro.close()
+            assert loop == depth.loop
+            return future
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", mock_run_coroutine_threadsafe)
+
+        depth.close_connection()
+
+        assert future.cancelled

--- a/tests/unit/test_dhanhq_marketfeed.py
+++ b/tests/unit/test_dhanhq_marketfeed.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import MagicMock, patch
 import pytest
 from dhanhq import MarketFeed, DhanContext
@@ -27,3 +28,58 @@ class TestMarketFeed:
         # Verify it tries to send subscription packet (implementation detail dependent)
         # For now, just ensuring method runs without error
         assert True
+
+    def test_disconnect_clears_and_closes_websocket(self, mock_context):
+        class MockWebSocket:
+            def __init__(self):
+                self.sent_messages = []
+                self.closed = False
+
+            async def send(self, message):
+                self.sent_messages.append(message)
+
+            async def close(self):
+                self.closed = True
+
+        instruments = [(1, "1333", 15)]
+        feed = MarketFeed(mock_context, instruments, version="v2")
+        ws = MockWebSocket()
+        feed.ws = ws
+
+        feed.loop.run_until_complete(feed.disconnect())
+
+        assert feed.ws is None
+        assert ws.closed
+        assert len(ws.sent_messages) == 2
+
+    def test_close_connection_cancels_disconnect_on_timeout(self, monkeypatch, mock_context):
+        class MockFuture:
+            def __init__(self):
+                self.cancelled = False
+
+            def result(self, timeout=None):
+                assert timeout == 5
+                raise TimeoutError
+
+            def cancel(self):
+                self.cancelled = True
+
+        class MockLoop:
+            def is_running(self):
+                return True
+
+        instruments = [(1, "1333", 15)]
+        feed = MarketFeed(mock_context, instruments, version="v2")
+        feed.loop = MockLoop()
+        future = MockFuture()
+
+        def mock_run_coroutine_threadsafe(coro, loop):
+            coro.close()
+            assert loop == feed.loop
+            return future
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", mock_run_coroutine_threadsafe)
+
+        feed.close_connection()
+
+        assert future.cancelled


### PR DESCRIPTION
Fixes #139.

## The bug

`close_connection()` can permanently freeze the calling thread when the WebSocket is stale or the server is unreachable.

**`MarketFeed` (before):**
```python
if self.loop.is_running():
    future = asyncio.run_coroutine_threadsafe(self.disconnect(), self.loop)
    return future.result()   # no timeout — blocks forever
```

**`FullDepth` (before):**
```python
def close_connection(self):
    return self.loop.run_until_complete(self.disconnect())
    # no loop.is_running() check → RuntimeError if called from async context
    # no timeout → blocks forever
```

When the socket is dead (e.g. after a network drop or a server-side timeout), `disconnect()` attempts to send a close message and then awaits `ws.close()`. Neither completes — the TCP handshake never finishes. The caller waits indefinitely. In production this surfaces as:

- **Ctrl+C hangs** — `run()` catches `KeyboardInterrupt` and calls `close_connection()`
- **Watchdog/reconnect logic freezes** — anything that calls `close_connection()` on a stale socket before reconnecting blocks permanently
- **Process managers (PM2, systemd) report the process as alive** while it is fully frozen

---

## Fix

### Layer 1 — `close_connection()` returns within 5 seconds

```python
if self.loop.is_running():
    future = asyncio.run_coroutine_threadsafe(self.disconnect(), self.loop)
    try:
        return future.result(timeout=5)
    except TimeoutError:
        future.cancel()   # stop the scheduled coroutine
        print("Warning: WebSocket disconnect timed out")
        return
else:
    if self.loop.is_closed():   # guard added — was missing in both classes
        return
    return self.loop.run_until_complete(self.disconnect())
```

`future.cancel()` is important: without it, the `disconnect()` coroutine remains scheduled in the event loop even after the caller returns, holding the socket reference and potentially interfering with a subsequent reconnect.

`FullDepth.close_connection()` is rewritten to match the `MarketFeed` pattern (it previously had none of this logic).

### Layer 2 — `disconnect()` operations are individually bounded

```python
await asyncio.wait_for(ws.send(disconnect_message), timeout=1)
await asyncio.wait_for(ws.send(header_message),     timeout=1)
...
await asyncio.wait_for(ws.close(), timeout=3)
```

`asyncio.wait_for()` is used rather than a plain `try/except Exception`. A bare exception catch handles errors but not a send or close that simply never completes. `wait_for()` covers both: it raises `asyncio.TimeoutError` (caught by the outer `except Exception`) if the operation stalls. This ensures the `disconnect()` coroutine itself completes promptly even when `future.cancel()` has not yet been called (e.g. the outer 5s has not expired yet).

The timeout budget is: send 1s + send 1s + close 3s = 5s total, fitting inside the outer 5s window.

### `self.ws = None` before closing (both classes)

```python
ws = self.ws
self.ws = None   # clear first
if ws:
    ...
    await ws.close()
```

Clearing `self.ws` before the async close prevents a TOCTOU window where `_run_async()` could read `self.ws`, see a non-None value, and call `ws.recv()` on a socket that `disconnect()` is simultaneously closing.

### `FullDepth.disconnect()` now closes the socket

Previously `FullDepth.disconnect()` sent a disconnect message to the server but never called `ws.close()`, leaving the underlying TCP connection open. This is fixed here.

---

## Tests

Added unit tests for both classes covering the two critical behaviors:

- `disconnect()` clears `self.ws` and closes the socket
- timeout path in `close_connection()` cancels the scheduled future

```
python -m pytest tests/unit/test_dhanhq_marketfeed.py tests/unit/test_dhanhq_fulldepth.py --no-cov
7 passed
```

The same fix pattern was applied to `OrderUpdate` in PR #131.